### PR TITLE
changed pet route endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ CodeFellows 401 JavaScipt final project RESTful API backend.
 #### Pet Create/POST Route
 /api/child/:childId/pet
 #### Pet Update/PUT Route
-/api/child/:childId/pet/:petId
+/api/child/:childId/pet
 #### Pet GET/GET Route
-/api/child/:childId/pet/:petId
+/api/child/:childId/pet
 #### Pet Delete/DELETE Route
-/api/child/:childId/pet/:petId
+/api/child/:childId/pet

--- a/route/pet-route.js
+++ b/route/pet-route.js
@@ -11,19 +11,19 @@ module.exports = function(router) {
       .catch(err => res.status(err.status));
   });
 
-  router.get('/child/:childId/pet/:petId', bearerAuth, (req, res) => {
+  router.get('/child/:childId/pet', bearerAuth, (req, res) => {
     return petController.getPet(req)
       .then(pet => res.status(200).json(pet))
       .catch(err => res.status(err.status));
   });
 
-  router.put('/child/:childId/pet/:petId', (req, res) => {
+  router.put('/child/:childId/pet', (req, res) => {
     return petController.putPet(req)
       .then(pet => res.status(200).json(pet))
       .catch(err => res.status(err.status));
   });
 
-  router.delete('/child/:childId/pet/:petId', bearerAuth, (req, res) => {
+  router.delete('/child/:childId/pet', bearerAuth, (req, res) => {
     petController.deletePet(req)
       .then(() => res.sendStatus(204))
       .catch(err => res.status(err.status));


### PR DESCRIPTION
While pair programming Carlo and I figured if we expect the child to only ever have one pet, we don't need the pets id in the pet routes since we also have the child's id in the pet routes. Easier to work with it in the front-end