### PR TITLE
Route hotfix

### DIFF
--- a/controller/pet-controller.js
+++ b/controller/pet-controller.js
@@ -10,12 +10,13 @@ exports.postPet = function(req) {
   let owner;
   Child.findById(req.params.childId)
     .then(child => {
-      if(child.pet.length === 1) Promise.reject(createError(400), 'You already have a pet!');
+      console.log(child);
       owner = child._id;
     });
 
   return new Pet(req.body).save()
     .then(pet => {
+      console.log('HERE');
       return Child.findByIdAndAddPet(owner, pet)
         .then(pet => pet)
         .catch(err => Promise.reject(createError(400), err.message));
@@ -25,25 +26,39 @@ exports.postPet = function(req) {
 };
 
 exports.getPet = function(req) {
-  return Pet.findById(req.params.petId)
+  let petId;
+  return Child.findById(req.params.childId)
+  .then(child => {
+    petId = child.pet[0];
+    return Pet.findById(petId)
+      .then(pet => pet)
+      .catch(err => Promise.reject(createError(400), err.message));
+  })
   .then(pet => pet)
   .catch(err => Promise.reject(createError(400), err.message));
 };
 
 exports.putPet = function(req) {
-  return Pet.findByIdAndUpdate(req.params.petId, req.body, {new: true})
+  let petId;
+  Child.findById(req.params.childId)
+  .then(child => {
+    petId = child.pet[0];
+  });
+  return Pet.findByIdAndUpdate(petId, req.body, {new: true})
     .then(pet => pet)
     .catch(err => Promise.reject(createError(400), err.message));
 };
 
 exports.deletePet = function(req) {
+  let petId;
   return Child.findById(req.params.childId)
     .then(child => {
+      petId = child.pet[0];
       child.pet = [];
       return child.save();
     })
     .then(() => {
-      return Pet.findByIdAndRemove(req.params.petId);
+      return Pet.findByIdAndRemove(petId);
     })
     .catch(err => Promise.reject(err.message));
 };

--- a/route/pet-route.js
+++ b/route/pet-route.js
@@ -22,8 +22,8 @@ module.exports = function(router) {
       .then(pet => res.status(200).json(pet))
       .catch(err => res.status(err.status));
   });
-  
-   router.put('/child/:childId/pet', (req, res) => {
+
+  router.put('/child/:childId/pet', (req, res) => {
     return petController.putPet(req)
       .then(pet => res.status(200).json(pet))
       .catch(err => res.status(err.status));


### PR DESCRIPTION
After changing the pet routes to not inlcude the id, I found most of the route controllers for the pet needed to be refactored accordingly. They all work now! 

BUGS:
1. In order to work, some controllers need CONSOLE.LOGS in very specific places.
This is not a new phenomenon.  I REPEAT. This is not a new phenomenon. There are a few places in the front end that also have this issue.

2. This doesn't appear to be an issue when interacting with the backend from the front end, but in POSTMAN, you must clear the collection of pets after deleting them before you can post another pet. 
